### PR TITLE
auto-config works without any external prompts besides the CLASSPATH

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -16,13 +16,19 @@
 
 package org.mybatis.spring.boot.autoconfigure;
 
-import javax.annotation.PostConstruct;
-import javax.sql.DataSource;
-
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.mapper.ClassPathMapperScanner;
+import org.mybatis.spring.mapper.MapperFactoryBean;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -30,59 +36,145 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+import java.util.List;
+
 /**
- * {@link EnableAutoConfiguration Auto-Configuration} for Mybatis.
+ * {@link EnableAutoConfiguration Auto-Configuration} for Mybatis. Contributes a
+ * {@link SqlSessionFactory} and a {@link SqlSessionTemplate}.
+ *
+ * If {@link org.mybatis.spring.annotation.MapperScan} is used, or a configuration
+ * file is specified as a property, those will be considered, otherwise this auto-configuration will attempt
+ * to register mappers based on the interface definitions in or under the root auto-configuration package.
  *
  * @author Eddú Meléndez
+ * @author <A href="mailto:starbuxman@gmail.com">Josh Long</A>
  */
 @Configuration
-@ConditionalOnClass({ SqlSessionFactory.class, SqlSessionFactoryBean.class })
+@ConditionalOnClass({SqlSessionFactory.class, SqlSessionFactoryBean.class})
 @ConditionalOnBean(DataSource.class)
 @EnableConfigurationProperties(MybatisProperties.class)
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
 public class MybatisAutoConfiguration {
 
-	@Autowired
-	private MybatisProperties properties;
+    private static Log log = LogFactory.getLog(MybatisAutoConfiguration.class);
 
-	@Autowired
-	private ResourceLoader resourceLoader = new DefaultResourceLoader();
+    @Autowired
+    private MybatisProperties properties;
 
-	@PostConstruct
-	public void checkConfigFileExists() {
-		if (this.properties.isCheckConfigLocation()) {
-			Resource resource = this.resourceLoader.getResource(this.properties
-					.getConfig());
-			Assert.state(resource.exists(), "Cannot find config location: " + resource
-					+ " (please add config file or check your Mybatis " + "configuration)");
-		}
-	}
+    @Autowired
+    private ResourceLoader resourceLoader = new DefaultResourceLoader();
 
-	@Bean
-	@ConditionalOnMissingBean
-	public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
-		SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
-		factory.setDataSource(dataSource);
-		if(StringUtils.hasText(this.properties.getConfig())) {
-			factory.setConfigLocation(this.resourceLoader.getResource(this.properties
-					.getConfig()));
-		}
-		return factory.getObject();
-	}
+    @PostConstruct
+    public void checkConfigFileExists() {
+        if (this.properties.isCheckConfigLocation()) {
+            Resource resource = this.resourceLoader.getResource(this.properties
+                    .getConfig());
+            Assert.state(resource.exists(), "Cannot find config location: " + resource
+                    + " (please add config file or check your Mybatis " + "configuration)");
+        }
+    }
 
-	@Bean
-	@ConditionalOnMissingBean
-	public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
-		return new SqlSessionTemplate(sqlSessionFactory,
-				this.properties.getExecutorType());
-	}
+    @Bean
+    @ConditionalOnMissingBean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        if (StringUtils.hasText(this.properties.getConfig())) {
+            factory.setConfigLocation(this.resourceLoader.getResource(this.properties
+                    .getConfig()));
+        }
+        return factory.getObject();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+        return new SqlSessionTemplate(sqlSessionFactory,
+                this.properties.getExecutorType());
+    }
+
+
+    /**
+     * This will just scan the same base package as Spring Boot does. If you want more power,
+     * you can explicitly use {@link org.mybatis.spring.annotation.MapperScan} but this will get
+     * typed mappers working correctly, out-of-the-box, similar to
+     * using Spring Data JPA repositories.
+     */
+    public static class AutoConfiguredMapperScannerRegistrar implements
+            BeanFactoryAware, ImportBeanDefinitionRegistrar, ResourceLoaderAware {
+
+        private BeanFactory beanFactory;
+
+        private ResourceLoader resourceLoader;
+
+        @Override
+        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+                                            BeanDefinitionRegistry registry) {
+
+            ClassPathMapperScanner scanner = new ClassPathMapperScanner(registry);
+
+            List<String> pkgs;
+            try {
+                pkgs = AutoConfigurationPackages.get(this.beanFactory);
+                for (String pkg : pkgs) {
+                    log.debug("found MyBatis auto-configuration package '" + pkg + "'");
+                }
+
+                if (this.resourceLoader != null) {
+                    scanner.setResourceLoader(this.resourceLoader);
+                }
+
+                scanner.registerFilters();
+                scanner.doScan(pkgs.toArray(new String[pkgs.size()]));
+            }
+            catch (IllegalStateException ex) {
+                log.debug("could not determine auto-configuration " +
+                        "package, automatic mapper scanning disabled.");
+            }
+        }
+
+        @Override
+        public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+            this.beanFactory = beanFactory;
+        }
+
+        @Override
+        public void setResourceLoader(ResourceLoader resourceLoader) {
+            this.resourceLoader = resourceLoader;
+        }
+    }
+
+    /**
+     * {@link org.mybatis.spring.annotation.MapperScan} ultimately ends up creating
+     * instances of {@link MapperFactoryBean}. If {@link org.mybatis.spring.annotation.MapperScan}
+     * is used then this auto-configuration is not needed. If it is _not_ used,
+     * however, then this will bring in a bean registrar and automatically
+     * register components based on the same component-scanning path as
+     * Spring Boot itself.
+     */
+    @Configuration
+    @Import({AutoConfiguredMapperScannerRegistrar.class})
+    @ConditionalOnMissingBean(MapperFactoryBean.class)
+    public static class MapperScannerRegistrarNotFoundConfiguration {
+
+        @PostConstruct
+        public void afterPropertiesSet() {
+            log.debug("no %s found, so " + MapperFactoryBean.class.getName());
+        }
+    }
 
 }

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -16,13 +16,13 @@
 
 package org.mybatis.spring.boot.autoconfigure;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.Test;
+import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.mybatis.spring.boot.autoconfigure.mapper.CityMapper;
 import org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.test.EnvironmentTestUtils;
@@ -30,62 +30,84 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Tests for {@link MybatisAutoConfiguration}
  *
  * @author Eddú Meléndez
+ * @author <A href="mailto:starbuxman@gmail.com">Josh Long</A>
  */
 public class MybatisAutoConfigurationTest {
 
-	private AnnotationConfigApplicationContext context;
+    private AnnotationConfigApplicationContext context;
 
-	@Test
-	public void testNoDataSource() throws Exception {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(MybatisAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
-		this.context.refresh();
-		assertEquals(0, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
-	}
+    @Test
+    public void testNoDataSource() throws Exception {
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(MybatisAutoConfiguration.class,
+                PropertyPlaceholderAutoConfiguration.class);
+        this.context.refresh();
+        assertEquals(0, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+    }
 
-	@Test
-	public void testDefaultConfiguration() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(EmbeddedDataSourceConfiguration.class,
-				MybatisScanMapperConfiguration.class, MybatisAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
-		this.context.refresh();
-		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
-		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
-	}
+    @Test
+    public void testDefaultConfiguration() {
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(EmbeddedDataSourceConfiguration.class,
+                MybatisScanMapperConfiguration.class, MybatisAutoConfiguration.class,
+                PropertyPlaceholderAutoConfiguration.class);
+        this.context.refresh();
+        assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+        assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+        assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+    }
 
-	@Test
-	public void testWithConfigFile() {
-		this.context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(this.context,
-				"mybatis.config:mybatis-config.xml");
-		this.context.register(EmbeddedDataSourceConfiguration.class,
-				MybatisAutoConfiguration.class, MybatisMapperConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
-		this.context.refresh();
-		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
-		assertEquals(1, this.context.getBeanNamesForType(CityMapperImpl.class).length);
-	}
+    @Test
+    public void testWithConfigFile() {
+        this.context = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(this.context,
+                "mybatis.config:mybatis-config.xml");
+        this.context.register(EmbeddedDataSourceConfiguration.class,
+                MybatisAutoConfiguration.class, MybatisMapperConfiguration.class,
+                PropertyPlaceholderAutoConfiguration.class);
+        this.context.refresh();
+        assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+        assertEquals(1, this.context.getBeanNamesForType(CityMapperImpl.class).length);
+    }
 
-	@Configuration
-	@MapperScan("org.mybatis.spring.boot.autoconfigure.mapper")
-	static class MybatisScanMapperConfiguration {
+    @Test
+    public void testDefaultBootConfiguration() {
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(EmbeddedDataSourceConfiguration.class,
+                MybatisBootMapperScanAutoConfiguration.class,
+                MybatisAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
+        this.context.refresh();
+        assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+        assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+        assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+    }
 
-	}
+    @Configuration
+    @EnableAutoConfiguration
+    @MapperScan("org.mybatis.spring.boot.autoconfigure.mapper")
+    static class MybatisScanMapperConfiguration {
+    }
 
-	@Configuration
-	static class MybatisMapperConfiguration {
+    @Configuration
+    @EnableAutoConfiguration
+    static class MybatisBootMapperScanAutoConfiguration {
+    }
 
-		@Bean
-		public CityMapperImpl cityMapper() {
-			return new CityMapperImpl();
-		}
+    @Configuration
+    @EnableAutoConfiguration
+    static class MybatisMapperConfiguration {
 
-	}
+        @Bean
+        public CityMapperImpl cityMapper() {
+            return new CityMapperImpl();
+        }
+
+    }
 
 }


### PR DESCRIPTION
Hi, with this PR it's possible to have mapper interfaces on the CLASSPATH and nothing but 

```
@SpringBootApplication 
public class Main { 
   public static void main( String [] args) { 
      SpringBootApplication.run (Main.class, args);
   }
}
```