### PR TITLE
Make SpringBootVFS work in tests

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/SpringBootVFS.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/SpringBootVFS.java
@@ -42,7 +42,7 @@ public class SpringBootVFS extends VFS {
     protected List<String> list(URL url, String path) throws IOException {
         ClassLoader cl = this.getClass().getClassLoader();
         ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(cl);
-        Resource[] resources = resolver.getResources(path + "/**/*.class");
+        Resource[] resources = resolver.getResources("classpath*:" + path + "/**/*.class");
         List<Resource> resources1 = Arrays.asList(resources);
         List<String> resourcePaths = new ArrayList<String>();
         for (Resource resource: resources1) {


### PR DESCRIPTION
`"classpath*:"` should be added to work in tests.

See a test revealing why this fix is needed:

https://github.com/izeye/spring-boot-throwaway-branches/blob/master/src/test/java/learningtest/org/springframework/core/io/support/PathMatchingResourcePatternResolverTests.java